### PR TITLE
Fix: Theme toggle icon displays incorrectly on light mode reload

### DIFF
--- a/components/toggle-theme.tsx
+++ b/components/toggle-theme.tsx
@@ -5,7 +5,7 @@ import { Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 
 export function ModeToggle() {
-  const { theme, setTheme } = useTheme()
+  const { theme, setTheme, resolvedTheme } = useTheme()
   const [mounted, setMounted] = React.useState(false)
 
   // useEffect only runs on the client, so now we can safely show the UI
@@ -14,10 +14,13 @@ export function ModeToggle() {
   }, [])
 
   function toggleTheme() {
-    const newTheme = theme === 'light' ? 'dark' : 'light'
-    localStorage.setItem('color-scheme', newTheme)
+    const currentTheme = resolvedTheme || theme
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light'
     setTheme(newTheme)
   }
+
+  // Use resolvedTheme to get the actual theme value (light/dark), not 'system'
+  const currentTheme = resolvedTheme || theme
 
   if (!mounted) {
     return (
@@ -53,7 +56,7 @@ export function ModeToggle() {
       <div className="flex items-center w-20 h-10 rounded-full bg-gray-300 dark:bg-gray-600 relative p-1 cursor-pointer transition-colors active:scale-95">
         <div
           className={`w-8 h-8 rounded-full shadow-md transform transition-transform duration-300 ease-in-out ${
-            theme === 'light'
+            currentTheme === 'light'
               ? 'translate-x-0 bg-white'
               : 'translate-x-10 bg-black'
           }`}
@@ -61,14 +64,14 @@ export function ModeToggle() {
 
         <Sun
           className={`absolute left-2 top-1/2 transform -translate-y-1/2 transition-opacity duration-300 ease-in-out ${
-            theme === 'light' ? 'opacity-100' : 'opacity-0'
+            currentTheme === 'light' ? 'opacity-100' : 'opacity-0'
           }`}
           size={24}
           color="orange"
         />
         <Moon
           className={`absolute right-2 top-1/2 transform -translate-y-1/2 transition-opacity duration-300 ease-in-out ${
-            theme === 'light' ? 'opacity-0' : 'opacity-100'
+            currentTheme === 'light' ? 'opacity-0' : 'opacity-100'
           }`}
           size={24} 
           color="yellow"


### PR DESCRIPTION
The Bug: When the page was reloaded in light mode, the toggle icon incorrectly showed the moon (dark mode icon). This was because the display logic checked the `theme` variable, which often returned `"system"` instead of the resolved theme (`"light"`).

The Fix:

Destructured and used `resolvedTheme` from `useTheme()`. This variable guarantees the actual, resolved theme value (`'light'` or `'dark'`).

Created a `currentTheme = resolvedTheme || theme` variable and updated all display logic (icon opacity and toggle position) to use it.

Removed manual `localStorage` manipulation, relying on `next-themes` for proper theme persistence.

Testing: Set light mode, reload the page, and the sun icon will correctly display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Theme toggle now consistently reflects the active theme throughout the application
  * Improved system theme preference detection to ensure the correct theme is applied based on system settings or user selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->