### PR TITLE
Fix Ergo button text color to remain white on hover

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,7 +73,7 @@ export default function HomePage() {
                 className="w-full md:w-auto font-bold relative overflow-hidden group
                   bg-gradient-to-r from-primary to-purple-600 hover:from-purple-600 hover:to-primary
                   transition-all duration-300 transform hover:scale-105 hover:shadow-2xl hover:shadow-primary/25
-                  border-0 text-primary-foreground"
+                  border-0 text-white hover:text-white"
               >
                 <span className="relative z-10">Ergo</span>
                 <div className="absolute inset-0 bg-gradient-to-r from-primary/10 to-purple-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />


### PR DESCRIPTION
https://github.com/StabilityNexus/hodlCoin-Website/issues/15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Ergo button text color styling to display white text by default and on hover.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->