### PR TITLE
Fix: The light/dark mode toggle is behaving strangely when the page is reloaded

### DIFF
--- a/components/toggle-theme.tsx
+++ b/components/toggle-theme.tsx
@@ -29,7 +29,8 @@ export function ModeToggle() {
   // Use resolvedTheme to get the actual theme value (light/dark), not 'system'
   const currentTheme = resolvedTheme || theme
 
-  if (!mounted) {
+  // Don't render the interactive toggle until both mounted and theme is resolved
+  if (!mounted || !resolvedTheme) {
     return (
       <div
         className="flex items-center space-x-4"
@@ -45,7 +46,7 @@ export function ModeToggle() {
           />
           <Moon
             className="absolute right-2 top-1/2 transform -translate-y-1/2 opacity-0"
-            size={24} 
+            size={24}
             color="yellow"
           />
         </div>
@@ -62,25 +63,22 @@ export function ModeToggle() {
     >
       <div className="flex items-center w-20 h-10 rounded-full bg-gray-300 dark:bg-gray-600 relative p-1 cursor-pointer transition-colors active:scale-95">
         <div
-          className={`w-8 h-8 rounded-full shadow-md transform transition-transform duration-300 ease-in-out ${
-            currentTheme === 'light'
-              ? 'translate-x-0 bg-white'
-              : 'translate-x-10 bg-black'
-          }`}
+          className={`w-8 h-8 rounded-full shadow-md transform transition-transform duration-300 ease-in-out ${currentTheme === 'light'
+            ? 'translate-x-0 bg-white'
+            : 'translate-x-10 bg-black'
+            }`}
         ></div>
 
         <Sun
-          className={`absolute left-2 top-1/2 transform -translate-y-1/2 transition-opacity duration-300 ease-in-out ${
-            currentTheme === 'light' ? 'opacity-100' : 'opacity-0'
-          }`}
+          className={`absolute left-2 top-1/2 transform -translate-y-1/2 transition-opacity duration-300 ease-in-out ${currentTheme === 'light' ? 'opacity-100' : 'opacity-0'
+            }`}
           size={24}
           color="orange"
         />
         <Moon
-          className={`absolute right-2 top-1/2 transform -translate-y-1/2 transition-opacity duration-300 ease-in-out ${
-            currentTheme === 'light' ? 'opacity-0' : 'opacity-100'
-          }`}
-          size={24} 
+          className={`absolute right-2 top-1/2 transform -translate-y-1/2 transition-opacity duration-300 ease-in-out ${currentTheme === 'light' ? 'opacity-0' : 'opacity-100'
+            }`}
+          size={24}
           color="yellow"
         />
       </div>


### PR DESCRIPTION
## Description
Fixes the theme toggle displaying the wrong icon after page reload.

## Problem
When the page was reloaded while in light mode, the toggle would incorrectly show a moon icon instead of the expected sun icon, even though the page correctly remained in light mode.

## Root Cause
The issue was a hydration timing problem with `next-themes`. The component would render before `resolvedTheme` was available from localStorage, causing a brief moment where the wrong icon was displayed.

## Solution
Modified [components/toggle-theme.tsx](cci:7://file:///home/rishabhg/hodlCoin-Website/components/toggle-theme.tsx:0:0-0:0) to wait for both `mounted` state and `resolvedTheme` to be available before rendering the interactive toggle. This ensures the correct icon is always displayed after hydration.

## Changes
- Updated the conditional check from `if (!mounted)` to `if (!mounted || !resolvedTheme)`
- Added explanatory comment about waiting for theme resolution

## Testing
Tested light mode reload - toggle correctly shows sun icon  
Tested dark mode reload - toggle correctly shows moon icon  
Theme persistence works correctly across reloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced theme toggle rendering to ensure proper initialization and display consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->