### PR TITLE
feat: add merge conflict labelling workflow

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,29 @@
+name: Label Merge Conflicts
+
+on:
+  push:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PRs with merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "PR has merge conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: |
+            ⚠️ **This PR has merge conflicts.**
+
+            Please resolve the merge conflicts before review.
+
+            Your PR will only be reviewed by a maintainer after all conflicts have been resolved.
+
+            📺 Watch this video to understand why conflicts occur and how to resolve them:
+            https://www.youtube.com/watch?v=Sqsz1-o7nXk


### PR DESCRIPTION
###  Addressed Issues:

This PR introduces an automated workflow that labels pull requests with merge conflicts using eps1lon/actions-label-merge-conflict.

When a PR has merge conflicts:

A label “PR has merge conflicts” is automatically added.
A comment is posted notifying the contributor.
The label is automatically removed once conflicts are resolved.

#### Why This Change?
Currently, maintainers must manually identify and notify contributors when their PR requires rebasing. This creates unnecessary review overhead and delays.

This workflow:

- Improves PR triage visibility
- Notifies contributors immediately when conflicts arise
- Reduces manual maintainer intervention
- Ensures PRs are conflict-free before review

Behavior
When merge conflicts appear:
Label added: PR has merge conflicts
>Comment posted:
⚠️ This PR has merge conflicts.
Please resolve the merge conflicts before review.
Your PR will only be reviewed by a maintainer after all conflicts have been resolved.
Watch this video to understand why conflicts occur and how to resolve them.

When conflicts are resolved:
Label is automatically removed.

###  Screenshots/Recordings:

TODO: If applicable, add screenshots or recordings that demonstrate the interface **before** and **after** the changes.


###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../[CONTRIBUTING.md](http://contributing.md/))
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated merge conflict detection and management system for pull requests. When conflicts are detected, the system automatically applies the "PR has merge conflicts" label and posts a comprehensive comment containing detailed step-by-step resolution guidance, industry best practices, and helpful reference materials to assist contributors in efficiently resolving conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->